### PR TITLE
Always send numSamples waveform data

### DIFF
--- a/src/ps6000d/WaveformServerThread.cpp
+++ b/src/ps6000d/WaveformServerThread.cpp
@@ -148,7 +148,7 @@ void WaveformServerThread()
 				client.SendLooped((uint8_t*)&config, sizeof(config));
 
 				//Send the actual waveform data
-				client.SendLooped((uint8_t*)waveformBuffers[i], g_captureMemDepth * sizeof(int16_t));
+				client.SendLooped((uint8_t*)waveformBuffers[i], numSamples * sizeof(int16_t));
 			}
 		}
 


### PR DESCRIPTION
Because we just told the other side to expect numSamples of data.