### PR TITLE
add 3000-series support

### DIFF
--- a/src/ps6000d/CMakeLists.txt
+++ b/src/ps6000d/CMakeLists.txt
@@ -16,8 +16,9 @@ if(WIN32)
 	# Windows specific include path
 	include_directories(${PICO_SDK_PATH}/inc/)
 else()
-	# Linux specific include path
-	include_directories(${PICO_SDK_PATH}/include/)
+	# Linux specific include paths
+	include_directories(${PICO_SDK_PATH}/include/libps3000a)
+	include_directories(${PICO_SDK_PATH}/include/libps6000a)
 endif()
 
 ###############################################################################

--- a/src/ps6000d/CMakeLists.txt
+++ b/src/ps6000d/CMakeLists.txt
@@ -1,25 +1,50 @@
-# Additional libraries on Windows
+
 if(WIN32)
+	# Windows additional options, libraries and default path (Picoscope SDK 64bits)
+	# Use MinGW formatting (C *printf Format "%zu"...) rather than MSVCRT for C99 support.
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__USE_MINGW_ANSI_STDIO=1")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_MINGW_ANSI_STDIO=1")
 	set(WIN_LIBS shlwapi)
-	endif()
+	set(PICO_SDK_PATH "C:/Program Files/Pico Technology/SDK")
+else()
+	# Linux specific Picoscope SDK Path
+	set(PICO_SDK_PATH "/opt/picoscope")
+endif()
 
 #Set up include paths
-include_directories('/opt/picoscope/include/')
+if(WIN32)
+	# Windows specific include path
+	include_directories(${PICO_SDK_PATH}/inc/)
+else()
+	# Linux specific include path
+	include_directories(${PICO_SDK_PATH}/include/)
+endif()
 
 ###############################################################################
 #C++ compilation
 add_executable(ps6000d
 	ScpiServerThread.cpp
 	WaveformServerThread.cpp
-
 	main.cpp
 )
 
 ###############################################################################
 #Linker settings
-target_link_libraries(ps6000d
+if(WIN32)
+	# Windows specific linker
+	target_link_libraries(ps6000d
 	xptools
 	log
-	/opt/picoscope/lib/libps3000a.so
-	/opt/picoscope/lib/libps6000a.so
+	${PICO_SDK_PATH}/lib/ps3000a.lib
+	${PICO_SDK_PATH}/lib/ps6000a.lib
 	)
+else()
+	# Linux specific linker
+	target_link_libraries(ps6000d
+	xptools
+	log
+	${PICO_SDK_PATH}/lib/libps3000a.so
+	${PICO_SDK_PATH}/lib/libps6000a.so
+	)
+endif()
+

--- a/src/ps6000d/CMakeLists.txt
+++ b/src/ps6000d/CMakeLists.txt
@@ -20,5 +20,6 @@ add_executable(ps6000d
 target_link_libraries(ps6000d
 	xptools
 	log
+	/opt/picoscope/lib/libps3000a.so
 	/opt/picoscope/lib/libps6000a.so
 	)

--- a/src/ps6000d/ScpiServerThread.cpp
+++ b/src/ps6000d/ScpiServerThread.cpp
@@ -276,7 +276,7 @@ void ScpiServerThread()
 						size_t maxSamples;
 						int32_t maxSamples_int;
 						PICO_STATUS status;
-
+						status = PICO_RESERVED_1;
 						if(g_pico_type == PICO6000A)
 							status = ps6000aGetTimebase(g_hScope, i, 1, &intervalNs, &maxSamples, 0);
 						else if(g_pico_type == PICO3000A)
@@ -309,7 +309,7 @@ void ScpiServerThread()
 					int32_t maxSamples_int;
 
 					PICO_STATUS status;
-
+					status = PICO_RESERVED_1;
 					//Ask for max memory depth at 1.25 Gsps. Why does legal memory depend on sample rate?
 					if(g_pico_type == PICO6000A)
 						status = ps6000aGetTimebase(g_hScope, 2, 1, &intervalNs, &maxSamples, 0);
@@ -910,9 +910,10 @@ void StartCapture(bool stopFirst)
 
 	//TODO: implement g_triggerDelay
 
-	LogVerbose("StartCapture stopFirst %d memdepth %d\n", stopFirst, g_memDepth);
+	LogVerbose("StartCapture stopFirst %d memdepth %zu\n", stopFirst, g_memDepth);
 
 	PICO_STATUS status;
+	status = PICO_RESERVED_1;
 	switch(g_pico_type)
 	{
 	case PICO3000A:

--- a/src/ps6000d/ScpiServerThread.cpp
+++ b/src/ps6000d/ScpiServerThread.cpp
@@ -112,9 +112,11 @@ void ParseScpiLine(const string& line, string& subject, string& cmd, bool& query
 map<size_t, bool> g_channelOn;
 map<size_t, PICO_COUPLING> g_coupling;
 map<size_t, PICO_CONNECT_PROBE_RANGE> g_range;
+map<size_t, enPS3000ARange> g_range_3000a;
 map<size_t, double> g_roundedRange;
 map<size_t, double> g_offset;
 map<size_t, PICO_BANDWIDTH_LIMITER> g_bandwidth;
+map<size_t, size_t> g_bandwidth_legacy;
 size_t g_memDepth = 1000000;
 int64_t g_sampleInterval = 0;	//in fs
 
@@ -189,8 +191,10 @@ void ScpiServerThread()
 		g_channelOn[i] = false;
 		g_coupling[i] = PICO_DC;
 		g_range[i] = PICO_X1_PROBE_1V;
+		g_range_3000a[i] = PS3000A_1V;
 		g_offset[i] = 0;
 		g_bandwidth[i] = PICO_BW_FULL;
+		g_bandwidth_legacy[i] = PS3000A_BW_FULL;
 	}
 
 	//Push initial trigger config
@@ -223,6 +227,7 @@ void ScpiServerThread()
 			if(!ScpiRecv(client, line))
 				break;
 			ParseScpiLine(line, subject, cmd, query, args);
+			LogVerbose((line + "\n").c_str());
 
 			//Extract channel ID from subject and clamp bounds
 			size_t channelId = 0;
@@ -267,12 +272,27 @@ void ScpiServerThread()
 					for(auto i : vec)
 					{
 						double intervalNs;
+						int32_t intervalNs_int;
 						size_t maxSamples;
-						if(PICO_OK == ps6000aGetTimebase(g_hScope, i, 1, &intervalNs, &maxSamples, 0))
+						int32_t maxSamples_int;
+						PICO_STATUS status;
+
+						if(g_pico_type == PICO6000A)
+							status = ps6000aGetTimebase(g_hScope, i, 1, &intervalNs, &maxSamples, 0);
+						else if(g_pico_type == PICO3000A)
+						{
+							status = ps3000aGetTimebase(g_hScope, i, 1, &intervalNs_int, 0, &maxSamples_int, 0);
+							intervalNs = intervalNs_int;
+							maxSamples = maxSamples_int;
+						}
+
+						if(PICO_OK == status)
 						{
 							size_t intervalFs = intervalNs * 1e6f;
 							ret += to_string(intervalFs) + ",";
 						}
+						else
+							LogWarning("GetTimebase failed, code %d / 0x%x\n", status, status);
 					}
 					ScpiSend(client, ret);
 				}
@@ -284,10 +304,19 @@ void ScpiServerThread()
 
 					lock_guard<mutex> lock(g_mutex);
 					double intervalNs;
+					int32_t intervalNs_int;
 					size_t maxSamples;
+					int32_t maxSamples_int;
+
+					PICO_STATUS status;
 
 					//Ask for max memory depth at 1.25 Gsps. Why does legal memory depend on sample rate?
-					if(PICO_OK == ps6000aGetTimebase(g_hScope, 2, 1, &intervalNs, &maxSamples, 0))
+					if(g_pico_type == PICO6000A)
+						status = ps6000aGetTimebase(g_hScope, 2, 1, &intervalNs, &maxSamples, 0);
+					else if(g_pico_type == PICO3000A)
+						status = ps3000aGetTimebase(g_hScope, 2, 1, &intervalNs_int, 0, &maxSamples_int, 0);
+
+					if(PICO_OK == status)
 					{
 						//Seems like there's no restrictions on actual memory depth other than an upper bound.
 						//To keep things simple, report 1-2-5 series from 10K samples up to the actual max depth
@@ -390,6 +419,9 @@ void ScpiServerThread()
 			{
 				lock_guard<mutex> lock(g_mutex);
 
+				if(g_pico_type != PICO6000A)
+					continue;
+
 				ps6000aStop(g_hScope);
 
 				//Even though we didn't actually change memory, apparently calling ps6000aSetDeviceResolution
@@ -438,10 +470,22 @@ void ScpiServerThread()
 
 				double requestedOffset = stod(args[0]);
 
-				//Clamp to allowed range
 				double maxoff;
 				double minoff;
-				ps6000aGetAnalogueOffsetLimits(g_hScope, g_range[channelId], g_coupling[channelId], &maxoff, &minoff);
+				float maxoff_f;
+				float minoff_f;
+
+				//Clamp to allowed range
+				switch(g_pico_type) {
+				case PICO3000A:
+					ps3000aGetAnalogueOffset(g_hScope, g_range_3000a[channelId], (PS3000A_COUPLING)g_coupling[channelId], &maxoff_f, &minoff_f);
+					maxoff = maxoff_f;
+					minoff = minoff_f;
+					break;
+				case PICO6000A:
+					ps6000aGetAnalogueOffsetLimits(g_hScope, g_range[channelId], g_coupling[channelId], &maxoff, &minoff);
+					break;
+				}
 				requestedOffset = min(maxoff, requestedOffset);
 				requestedOffset = max(minoff, requestedOffset);
 
@@ -458,12 +502,12 @@ void ScpiServerThread()
 				if(g_coupling[channelId] == PICO_DC_50OHM)
 					range = min(range, 5.0);
 
-				if(range > 100)
+				if(range > 100 && g_pico_type == PICO6000A)
 				{
 					g_range[channelId] = PICO_X1_PROBE_200V;
 					g_roundedRange[channelId] = 200;
 				}
-				else if(range > 50)
+				else if(range > 50 && g_pico_type == PICO6000A)
 				{
 					g_range[channelId] = PICO_X1_PROBE_100V;
 					g_roundedRange[channelId] = 100;
@@ -471,61 +515,73 @@ void ScpiServerThread()
 				else if(range > 20)
 				{
 					g_range[channelId] = PICO_X1_PROBE_50V;
+					g_range_3000a[channelId] = PS3000A_50V;
 					g_roundedRange[channelId] = 50;
 				}
 				else if(range > 10)
 				{
 					g_range[channelId] = PICO_X1_PROBE_20V;
+					g_range_3000a[channelId] = PS3000A_20V;
 					g_roundedRange[channelId] = 20;
 				}
 				else if(range > 5)
 				{
 					g_range[channelId] = PICO_X1_PROBE_10V;
+					g_range_3000a[channelId] = PS3000A_10V;
 					g_roundedRange[channelId] = 10;
 				}
 				else if(range > 2)
 				{
 					g_range[channelId] = PICO_X1_PROBE_5V;
+					g_range_3000a[channelId] = PS3000A_5V;
 					g_roundedRange[channelId] = 5;
 				}
 				else if(range > 1)
 				{
 					g_range[channelId] = PICO_X1_PROBE_2V;
+					g_range_3000a[channelId] = PS3000A_2V;
 					g_roundedRange[channelId] = 2;
 				}
 				else if(range > 0.5)
 				{
 					g_range[channelId] = PICO_X1_PROBE_1V;
+					g_range_3000a[channelId] = PS3000A_1V;
 					g_roundedRange[channelId] = 1;
 				}
 				else if(range > 0.2)
 				{
 					g_range[channelId] = PICO_X1_PROBE_500MV;
+					g_range_3000a[channelId] = PS3000A_500MV;
 					g_roundedRange[channelId] = 0.5;
 				}
 				else if(range > 0.1)
 				{
 					g_range[channelId] = PICO_X1_PROBE_200MV;
+					g_range_3000a[channelId] = PS3000A_200MV;
 					g_roundedRange[channelId] = 0.2;
 				}
 				else if(range >= 0.05)
 				{
 					g_range[channelId] = PICO_X1_PROBE_100MV;
+					g_range_3000a[channelId] = PS3000A_100MV;
 					g_roundedRange[channelId] = 0.1;
 				}
 				else if(range >= 0.02)
 				{
 					g_range[channelId] = PICO_X1_PROBE_50MV;
+					g_range_3000a[channelId] = PS3000A_50MV;
 					g_roundedRange[channelId] = 0.05;
 				}
 				else if(range >= 0.01)
 				{
 					g_range[channelId] = PICO_X1_PROBE_20MV;
+					g_range_3000a[channelId] = PS3000A_20MV;
 					g_roundedRange[channelId] = 0.02;
 				}
 				else
 				{
 					g_range[channelId] = PICO_X1_PROBE_10MV;
+					g_range_3000a[channelId] = PS3000A_10MV;
 					g_roundedRange[channelId] = 0.01;
 				}
 
@@ -562,6 +618,11 @@ void ScpiServerThread()
 			{
 				lock_guard<mutex> lock(g_mutex);
 				g_memDepth = stoull(args[0]);
+
+				if(g_captureMemDepth != g_memDepth)
+					g_memDepthChanged = true;
+				if(g_triggerArmed)
+					StartCapture(true);
 			}
 
 			else if( (cmd == "START") || (cmd == "SINGLE") )
@@ -599,7 +660,11 @@ void ScpiServerThread()
 			{
 				lock_guard<mutex> lock(g_mutex);
 
-				ps6000aStop(g_hScope);
+				if(g_pico_type == PICO3000A)
+					ps3000aStop(g_hScope);
+				else if(g_pico_type == PICO6000A)
+					ps6000aStop(g_hScope);
+
 				g_triggerArmed = false;
 			}
 
@@ -671,11 +736,24 @@ void ScpiServerThread()
 
 		//Disable all channels when a client disconnects to put the scope in a "safe" state
 		for(auto it : g_channelOn)
-			ps6000aSetChannelOff(g_hScope, (PICO_CHANNEL)it.first);
-		for(int i=0; i<2; i++)
 		{
-			ps6000aSetDigitalPortOff(g_hScope, (PICO_CHANNEL)(PICO_PORT0 + i));
-			g_msoPodEnabled[i] = false;
+			switch(g_pico_type)
+			{
+			case PICO3000A:
+				ps3000aSetChannel(g_hScope, (PS3000A_CHANNEL)it.first, 0, PS3000A_DC, PS3000A_1V, 0.0f);
+				break;
+			case PICO6000A:
+				ps6000aSetChannelOff(g_hScope, (PICO_CHANNEL)it.first);
+				break;
+			}
+		}
+		if(g_pico_type == PICO6000A)
+		{
+			for(int i=0; i<2; i++)
+			{
+				ps6000aSetDigitalPortOff(g_hScope, (PICO_CHANNEL)(PICO_PORT0 + i));
+				g_msoPodEnabled[i] = false;
+			}
 		}
 
 		g_waveformThreadQuit = true;
@@ -752,6 +830,17 @@ void ParseScpiLine(const string& line, string& subject, string& cmd, bool& query
  */
 void UpdateChannel(size_t chan)
 {
+	if(g_pico_type == PICO3000A)
+	{
+		ps3000aSetChannel(g_hScope, (PS3000A_CHANNEL)chan, g_channelOn[chan],
+			(PS3000A_COUPLING)g_coupling[chan], g_range_3000a[chan], -g_offset[chan]);
+		ps3000aSetBandwidthFilter(g_hScope, (PS3000A_CHANNEL)chan,
+			(PS3000A_BANDWIDTH_LIMITER)g_bandwidth_legacy[chan]);
+		if(chan == g_triggerChannel)
+			UpdateTrigger();
+		return;
+	}
+
 	if(g_channelOn[chan])
 	{
 		ps6000aSetChannelOn(g_hScope, (PICO_CHANNEL)chan,
@@ -783,14 +872,29 @@ void UpdateTrigger()
 	//TODO: Convert delay from fs to native units (samples? ps?)
 	uint64_t delay = 0;
 
-	ps6000aSetSimpleTrigger(
-		g_hScope,
-		1,
-		(PICO_CHANNEL)g_triggerChannel,
-		round(trig_code),
-		g_triggerDirection,
-		delay,
-		0);
+	switch(g_pico_type)
+	{
+	case PICO3000A:
+		ps3000aSetSimpleTrigger(
+			g_hScope,
+			1,
+			(PS3000A_CHANNEL)g_triggerChannel,
+			round(trig_code),
+			(enPS3000AThresholdDirection)g_triggerDirection, // same as 6000a api
+			delay,
+			0);
+		break;
+	case PICO6000A:
+		ps6000aSetSimpleTrigger(
+			g_hScope,
+			1,
+			(PICO_CHANNEL)g_triggerChannel,
+			round(trig_code),
+			g_triggerDirection,
+			delay,
+			0);
+		break;
+	}
 
 	if(g_triggerArmed)
 		StartCapture(true);
@@ -806,10 +910,23 @@ void StartCapture(bool stopFirst)
 
 	//TODO: implement g_triggerDelay
 
-	if(stopFirst)
-		ps6000aStop(g_hScope);
+	LogVerbose("StartCapture stopFirst %d memdepth %d\n", stopFirst, g_memDepth);
 
-	auto status = ps6000aRunBlock(g_hScope, g_memDepth/2, g_memDepth/2, g_timebase, NULL, 0, NULL, NULL);
+	PICO_STATUS status;
+	switch(g_pico_type)
+	{
+	case PICO3000A:
+		if(stopFirst)
+			ps3000aStop(g_hScope);
+		// TODO: why the 1
+		status = ps3000aRunBlock(g_hScope, g_memDepth/2, g_memDepth/2, g_timebase, 1, NULL, 0, NULL, NULL);
+		break;
+	case PICO6000A:
+		if(stopFirst)
+			ps6000aStop(g_hScope);
+		status = ps6000aRunBlock(g_hScope, g_memDepth/2, g_memDepth/2, g_timebase, NULL, 0, NULL, NULL);
+		break;
+	}
 
 	//not sure why this happens...
 	if(status == PICO_HARDWARE_CAPTURING_CALL_STOP)

--- a/src/ps6000d/WaveformServerThread.cpp
+++ b/src/ps6000d/WaveformServerThread.cpp
@@ -69,7 +69,7 @@ void WaveformServerThread()
 
 		if( (ready == 0) || (!g_triggerArmed) )
 		{
-			usleep(1000);
+			std::this_thread::sleep_for(std::chrono::microseconds(1000));
 			continue;
 		}
 

--- a/src/ps6000d/ps6000d.h
+++ b/src/ps6000d/ps6000d.h
@@ -41,9 +41,16 @@
 #include <map>
 #include <mutex>
 
+#include "/opt/picoscope/include/libps3000a/ps3000aApi.h"
 #include "/opt/picoscope/include/libps6000a/ps6000aApi.h"
 #include "/opt/picoscope/include/libps6000a/PicoStatus.h"
 #include "/opt/picoscope/include/libps6000a/PicoVersion.h"
+
+enum PicoScopeType
+{
+	PICO3000A,
+	PICO6000A
+};
 
 extern Socket g_scpiSocket;
 extern Socket g_dataSocket;
@@ -52,6 +59,7 @@ extern int16_t g_hScope;
 void ScpiServerThread();
 void WaveformServerThread();
 
+extern PicoScopeType g_pico_type;
 extern std::string g_model;
 extern std::string g_serial;
 extern std::string g_fwver;

--- a/src/ps6000d/ps6000d.h
+++ b/src/ps6000d/ps6000d.h
@@ -30,21 +30,22 @@
 #ifndef ps6000d_h
 #define ps6000d_h
 
+#include "../../lib/log/log.h"
+#include "../../lib/xptools/Socket.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #include <shlwapi.h>
 #endif
 
-#include "../../lib/log/log.h"
-#include "../../lib/xptools/Socket.h"
 #include <thread>
 #include <map>
 #include <mutex>
 
-#include "/opt/picoscope/include/libps3000a/ps3000aApi.h"
-#include "/opt/picoscope/include/libps6000a/ps6000aApi.h"
-#include "/opt/picoscope/include/libps6000a/PicoStatus.h"
-#include "/opt/picoscope/include/libps6000a/PicoVersion.h"
+#include "ps3000aApi.h"
+#include "ps6000aApi.h"
+#include "PicoStatus.h"
+#include "PicoVersion.h"
 
 enum PicoScopeType
 {


### PR DESCRIPTION
This adds support for the 3000A series.

We still need to change the name from ps6000d and tidy up some of the coding style. Might also want to get rid of the g_bandwidth_legacy global (and maybe the g_range_3000a) one - both the globals can be either used as-is (bandwidth) or translated with a simple offset (range).