### PR TITLE
macOS fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(ANALYZE CACHE BOOL "Run static analysis on the code, requires cppcheck and c
 set(WARNINGS "-Wall -Wextra -Wuninitialized ")
 set(WARNINGS "${WARNINGS} -Wshadow -Wunsafe-loop-optimizations -Wpedantic -Wcast-align -Wwrite-strings")
 set(WARNINGS "${WARNINGS} -Wmissing-declarations -Wvla")
-set(CMAKE_CXX_FLAGS "-g -fopenmp ${WARNINGS} --std=c++11 -ffast-math")
+set(CMAKE_CXX_FLAGS "-g ${WARNINGS} --std=c++11 -ffast-math")
 if(NOT (APPLE AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64"))
 	message(${CMAKE_HOST_SYSTEM_PROCESSOR})
 	# we can not build for arm64, but mtune=native will still somehow resolve to apple-m1 or similar,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,15 @@ set(ANALYZE CACHE BOOL "Run static analysis on the code, requires cppcheck and c
 set(WARNINGS "-Wall -Wextra -Wuninitialized ")
 set(WARNINGS "${WARNINGS} -Wshadow -Wunsafe-loop-optimizations -Wpedantic -Wcast-align -Wwrite-strings")
 set(WARNINGS "${WARNINGS} -Wmissing-declarations -Wvla")
-set(CMAKE_CXX_FLAGS "-g -fopenmp ${WARNINGS} --std=c++11 -mtune=native -ffast-math")
+set(CMAKE_CXX_FLAGS "-g -fopenmp ${WARNINGS} --std=c++11 -ffast-math")
+if(NOT (APPLE AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64"))
+	message(${CMAKE_HOST_SYSTEM_PROCESSOR})
+	# we can not build for arm64, but mtune=native will still somehow resolve to apple-m1 or similar,
+	# which x86 apple clang does not understand.
+	# Only set mtune=native if we're *not* building on an Apple Silicon host.
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=native")
+endif()
+
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fsanitize=address")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(CMAKE_CXX_FLAGS "-g -fopenmp ${WARNINGS} --std=c++11 -mtune=native -ffast-ma
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fsanitize=address")
 
+if(APPLE AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
+	# force x86 build, PicoSDK is only built for Intel macs as of 10.7.26.362, so arm64 can't link against it
+	set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
+endif ()
+
 if(WIN32)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_USE_MATH_DEFINES -D_POSIX_THREAD_SAFE_FUNCTIONS")
 endif()

--- a/src/ps6000d/CMakeLists.txt
+++ b/src/ps6000d/CMakeLists.txt
@@ -6,6 +6,11 @@ if(WIN32)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_MINGW_ANSI_STDIO=1")
 	set(WIN_LIBS shlwapi)
 	set(PICO_SDK_PATH "C:/Program Files/Pico Technology/SDK")
+elseif(APPLE)
+	find_library(PICO_SDK_FRAMEWORK PicoSDK)
+	if (NOT PICO_SDK_FRAMEWORK)
+		message(FATAL_ERROR PicoSDK not installed)
+	endif()
 else()
 	# Linux specific Picoscope SDK Path
 	set(PICO_SDK_PATH "/opt/picoscope")
@@ -15,6 +20,9 @@ endif()
 if(WIN32)
 	# Windows specific include path
 	include_directories(${PICO_SDK_PATH}/inc/)
+elseif(APPLE)
+	include_directories(${PICO_SDK_FRAMEWORK}/Headers/libps3000a)
+	include_directories(${PICO_SDK_FRAMEWORK}/Headers/libps6000a)
 else()
 	# Linux specific include paths
 	include_directories(${PICO_SDK_PATH}/include/libps3000a)
@@ -40,6 +48,13 @@ if(WIN32)
 	${PICO_SDK_PATH}/lib/ps3000a.lib
 	${PICO_SDK_PATH}/lib/ps6000a.lib
 	)
+elseif(APPLE)
+	target_link_libraries(ps6000d
+	xptools
+	log
+	scpi-server-tools
+	${PICO_SDK_FRAMEWORK}/Libraries/libps3000a/libps3000a.dylib
+	${PICO_SDK_FRAMEWORK}/Libraries/libps6000a/libps6000a.dylib)
 else()
 	# Linux specific linker
 	target_link_libraries(ps6000d

--- a/src/ps6000d/PicoSCPIServer.cpp
+++ b/src/ps6000d/PicoSCPIServer.cpp
@@ -374,7 +374,7 @@ vector<size_t> PicoSCPIServer::GetSampleRates()
 	{
 		double intervalNs;
 		int32_t intervalNs_int;
-		size_t maxSamples;
+		uint64_t maxSamples;
 		int32_t maxSamples_int;
 		PICO_STATUS status = PICO_RESERVED_1;
 
@@ -415,7 +415,7 @@ vector<size_t> PicoSCPIServer::GetSampleDepths()
 	lock_guard<mutex> lock(g_mutex);
 	double intervalNs;
 	int32_t intervalNs_int;
-	size_t maxSamples;
+	uint64_t maxSamples;
 	int32_t maxSamples_int;
 
 	PICO_STATUS status;

--- a/src/ps6000d/WaveformServerThread.cpp
+++ b/src/ps6000d/WaveformServerThread.cpp
@@ -64,7 +64,7 @@ void WaveformServerThread()
 		g_channelIDs.push_back((PICO_CHANNEL)(PICO_PORT0 + i));
 
 	map<size_t, int16_t*> waveformBuffers;
-	size_t numSamples = 0;
+	uint64_t numSamples = 0;
 	uint32_t numSamples_int = 0;
 	uint16_t numchans;
 	while(!g_waveformThreadQuit)


### PR DESCRIPTION
While trying to add support for the (ancient) Picoscope 5203, I stumbled upon some issues trying to build this on macOS ARM.

Where necessary, I tried to explain some of my reasoning in comments and/or commit messages.

I'm not super sure about removing -fopenmp in particular, though it seems to build fine without? All the heavy lifting seens to happen in scopehal anyway, so it's not really needed here, right? I've never worked with it before.