### PR TITLE
Fix incorrect string search logic for 3000 non MSO models

### DIFF
--- a/src/ps6000d/main.cpp
+++ b/src/ps6000d/main.cpp
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
 				MSO if MSO option is available
 				example 3406DMSO (full option)
 			*/
-			if(g_model.find("MSO") > 0)
+			if(g_model.find("MSO") != std::string::npos)
 			{
 				g_numDigitalPods = 2;
 			}
@@ -382,4 +382,3 @@ void OnQuit(int /*signal*/)
 	}
 	exit(0);
 }
-

--- a/src/ps6000d/main.cpp
+++ b/src/ps6000d/main.cpp
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
 				MSO if MSO option is available
 				example 3406DMSO (full option)
 			*/
-			if(g_model.find("MSO") != std::string::npos)
+			if(g_model.find("MSO") != string::npos)
 			{
 				g_numDigitalPods = 2;
 			}


### PR DESCRIPTION
I own a 3404D (non MSO) scope. The bridge terminated as it tried to assign a buffer for a non existing channel

the reason was an incorrect string comparison when checking for MSO models. The previous implementation `g_model.find("MSO") > 0` would incorrectly return true for non-MSO models due to `string::find()` returning `npos (-1) `which wraps to a large positive number. Changed to use the proper `string::npos comparison`.

Thanks for this great peace of software!